### PR TITLE
Add supplemented GTFS headsign support

### DIFF
--- a/backend/test_helpers_test.go
+++ b/backend/test_helpers_test.go
@@ -27,9 +27,4 @@ func initTestCaches() {
 		Expiration(30 * time.Second).
 		Build()
 
-	// Supplemented GTFS cache: 30-minute TTL for trips data
-	supplementedGTFSCache = gcache.New(1).
-		LRU().
-		Expiration(30 * time.Minute).
-		Build()
 }

--- a/backend/test_helpers_test.go
+++ b/backend/test_helpers_test.go
@@ -26,4 +26,10 @@ func initTestCaches() {
 		LRU().
 		Expiration(30 * time.Second).
 		Build()
+
+	// Supplemented GTFS cache: 30-minute TTL for trips data
+	supplementedGTFSCache = gcache.New(1).
+		LRU().
+		Expiration(30 * time.Minute).
+		Build()
 }

--- a/tests/test_api.sh
+++ b/tests/test_api.sh
@@ -29,9 +29,17 @@ echo "$response" | jq '{
   first_5_departures: (.departures[0:5] | map({
     route: .route_id,
     direction: .direction,
-    eta_minutes: .eta_minutes
+    eta_minutes: .eta_minutes,
+    headsign: .headsign
   }))
 }'
+
+# Check if headsigns are being returned
+echo
+echo "Verifying headsign data:"
+headsigns_found=$(echo "$response" | jq '.departures | map(.headsign) | map(select(. != "")) | length')
+total_departures=$(echo "$response" | jq '.departures | length')
+echo "✓ Found $headsigns_found headsigns out of $total_departures departures"
 
 # Verify the 2 per route/direction limit
 echo
@@ -60,9 +68,15 @@ echo "$response" | jq '{
   departures_by_route: (.departures | group_by("\(.route_id)_\(.direction)") | map({
     route_direction: "\(.[0].route_id)_\(.[0].direction)",
     count: length,
-    times: map(.eta_minutes)
+    times: map(.eta_minutes),
+    headsigns: map(.headsign)
   }))
 }'
+
+# Check headsigns for this station  
+headsigns_127=$(echo "$response" | jq '.departures | map(.headsign) | map(select(. != "")) | length')
+total_127=$(echo "$response" | jq '.departures | length')
+echo "✓ Found $headsigns_127 headsigns out of $total_127 departures"
 
 # Check departure limit for this station
 violations=$(echo "$response" | jq '.departures | group_by("\(.route_id)_\(.direction)") | map({


### PR DESCRIPTION
Implements supplemented GTFS feed integration for enhanced headsigns:

**Features:**
- Downloads and parses trips.txt from supplemented GTFS feed
- 30-minute TTL cache for supplemented data (upstream updates hourly)
- Automatic background refresh every 30 minutes
- Prioritizes supplemented feed, falls back to regular feed
- Comprehensive logging for headsign source and timing
- Environment variable support for SUPPLEMENTED_GTFS_URL

**Testing:**
- Added comprehensive unit tests for all new functionality
- Enhanced API test script to verify headsign data
- All existing tests continue to pass

Fixes #2

Generated with [Claude Code](https://claude.ai/code)